### PR TITLE
chore: export constants

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./order";
 export * from "./builder";
 export * from "./utils";
+export * from "./constants";


### PR DESCRIPTION
export constants so gouda-api can reuse the address mappings.