### PR TITLE
Remove prepare script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:unit": "jest --testPathPattern src",
     "test:integration": "yarn build && cd integration && yarn && yarn test",
-    "prepare": "npm run build",
     "typechain": "typechain --target=ethers-v5 --out-dir src/contracts --glob ./abis/**/*.json"
   },
   "peerDependencies": {},


### PR DESCRIPTION
## Summary
GitHub linter is failing to import this private repo into the gouda-service in my PR [here](https://github.com/Uniswap/gouda-service/pull/17/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R60). I suspect this is because of the `prepare` script in the package.json. I found [this thread](https://github.com/yarnpkg/yarn/issues/6312#issuecomment-422806004) that shows a very similar issue and remove the script fixed the issue. 