### PR TITLE
feat: add validation parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ const serializedOrder = order.serialize();
 
 ### Parsing Orders
 ```ts
-import { parseOrder, IOrder, OrderValidation } from '@uniswap/gouda-sdk';
+import { parseOrder, Order, OrderValidation } from '@uniswap/gouda-sdk';
 
 const serializedOrder = '0x1111222233334444555500000000234300234...';
-const order: IOrder = parseOrder(serializedOrder);
+const order: Order = parseOrder(serializedOrder);
 
 const orderData = order.info;
 const orderHash = order.hash();

--- a/src/builder/OrderBuilder.ts
+++ b/src/builder/OrderBuilder.ts
@@ -1,7 +1,7 @@
 import { BigNumber, ethers } from "ethers";
 import invariant from "tiny-invariant";
 
-import { IOrder, OrderInfo } from "../order";
+import { Order, OrderInfo } from "../order";
 
 /**
  * Builder for generating orders
@@ -64,5 +64,5 @@ export abstract class OrderBuilder {
     };
   }
 
-  abstract build(): IOrder;
+  abstract build(): Order;
 }

--- a/src/order/DutchLimitOrder.ts
+++ b/src/order/DutchLimitOrder.ts
@@ -10,7 +10,7 @@ import { BigNumber, ethers } from "ethers";
 import { PERMIT2_MAPPING } from "../constants";
 import { MissingConfiguration } from "../errors";
 
-import { IOrder, OrderInfo } from "./types";
+import { Order, OrderInfo } from "./types";
 
 export type DutchOutput = {
   readonly token: string;
@@ -79,7 +79,7 @@ const DUTCH_LIMIT_ORDER_ABI = [
     ")",
 ];
 
-export class DutchLimitOrder implements IOrder {
+export class DutchLimitOrder extends Order {
   public permit2Address: string;
 
   constructor(
@@ -87,6 +87,7 @@ export class DutchLimitOrder implements IOrder {
     public readonly chainId: number,
     readonly _permit2Address?: string
   ) {
+    super();
     if (_permit2Address) {
       this.permit2Address = _permit2Address;
     } else if (PERMIT2_MAPPING[chainId]) {
@@ -146,7 +147,7 @@ export class DutchLimitOrder implements IOrder {
   }
 
   /**
-   * @inheritdoc IOrder
+   * @inheritdoc Order
    */
   serialize(): string {
     const abiCoder = new ethers.utils.AbiCoder();
@@ -179,7 +180,7 @@ export class DutchLimitOrder implements IOrder {
   }
 
   /**
-   * @inheritdoc IOrder
+   * @inheritdoc Order
    */
   getSigner(signature: SignatureLike): string {
     return ethers.utils.computeAddress(
@@ -196,7 +197,7 @@ export class DutchLimitOrder implements IOrder {
   }
 
   /**
-   * @inheritdoc IOrder
+   * @inheritdoc Order
    */
   permitData(): PermitTransferFromData {
     return SignatureTransfer.getPermitData(
@@ -208,7 +209,7 @@ export class DutchLimitOrder implements IOrder {
   }
 
   /**
-   * @inheritdoc IOrder
+   * @inheritdoc Order
    */
   hash(): string {
     return ethers.utils._TypedDataEncoder

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -3,10 +3,11 @@ import { MissingConfiguration } from "../errors";
 import { stripHexPrefix } from "../utils";
 
 import { DutchLimitOrder } from "./DutchLimitOrder";
-import { IOrder } from "./types";
+import { Order } from "./types";
 
 export * from "./DutchLimitOrder";
 export * from "./types";
+export * from "./validation";
 
 const FIRST_FIELD_OFFSET = 88;
 const ADDRESS_LENGTH = 40;
@@ -15,7 +16,7 @@ const ADDRESS_LENGTH = 40;
  * Parses a given serialized order
  * @return Parsed order object
  */
-export function parseOrder(order: string): IOrder {
+export function parseOrder(order: string): Order {
   // reactor address is always the first field in order
   const reactor =
     "0x" +

--- a/src/order/types.ts
+++ b/src/order/types.ts
@@ -2,12 +2,14 @@ import { SignatureLike } from "@ethersproject/bytes";
 import { PermitTransferFromData } from "@uniswap/permit2-sdk";
 import { BigNumber } from "ethers";
 
-export type IOrder = {
+import { CustomOrderValidation, parseValidation } from "./validation";
+
+export abstract class Order {
   // TODO: maybe add generic types for more order-type specific info
-  info: OrderInfo;
+  abstract info: OrderInfo;
 
   // expose the chainid
-  chainId: number;
+  abstract chainId: number;
 
   // TODO: maybe add generic order info getters, i.e.
   // affectedTokens, validTimes, max amounts?
@@ -17,27 +19,35 @@ export type IOrder = {
    * Returns the abi encoded order
    * @return The abi encoded serialized order which can be submitted on-chain
    */
-  serialize(): string;
+  abstract serialize(): string;
 
   /**
    * Recovers the given signature, returning the address which created it
    *  * @param signature The signature to recover
    *  * @returns address The address which created the signature
    */
-  getSigner(signature: SignatureLike): string;
+  abstract getSigner(signature: SignatureLike): string;
 
   /**
    * Returns the data for generating the maker EIP-712 permit signature
    * @return The data for generating the maker EIP-712 permit signature
    */
-  permitData(): PermitTransferFromData;
+  abstract permitData(): PermitTransferFromData;
 
   /**
    * Returns the order hash
    * @return The order hash which is used as a key on-chain
    */
-  hash(): string;
-};
+  abstract hash(): string;
+
+  /**
+   * Returns the parsed validation
+   * @return The parsed validation data for the order
+   */
+  get validation(): CustomOrderValidation {
+    return parseValidation(this.info);
+  }
+}
 
 export type TokenAmount = {
   readonly token: string;

--- a/src/order/validation.test.ts
+++ b/src/order/validation.test.ts
@@ -1,0 +1,52 @@
+import { BigNumber, ethers } from "ethers";
+
+import { OrderInfo } from "./types";
+import { parseValidation, ValidationType } from "./validation";
+
+describe("OrderValidation", () => {
+  it("parses an ExclusiveFiller validation", () => {
+    const validation = parseValidation(
+      makeOrderInfo(
+        "0x0000000000000000000000007fa9385be102ac3eac297483dd6233d62b3e14960000000000000000000000000000000000000000000000000000000000000033"
+      )
+    );
+    expect(validation).toEqual({
+      type: ValidationType.ExclusiveFiller,
+      data: {
+        filler: "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+        lastExclusiveTimestamp: 51,
+      },
+    });
+  });
+
+  it("parses empty validation data", async () => {
+    const validation = parseValidation(makeOrderInfo("0x"));
+    expect(validation).toEqual({
+      type: ValidationType.None,
+      data: null,
+    });
+  });
+
+  it("parses invalid validation data", async () => {
+    const validation = parseValidation(
+      makeOrderInfo(
+        "0x0000000000000000000000007fa9385be102ac3eac297483dd6233d62b3e1496000000000000000000000000000000000000000000000000000000000000033"
+      )
+    );
+    expect(validation).toEqual({
+      type: ValidationType.None,
+      data: null,
+    });
+  });
+});
+
+function makeOrderInfo(data: string): OrderInfo {
+  return {
+    reactor: ethers.constants.AddressZero,
+    offerer: ethers.constants.AddressZero,
+    nonce: BigNumber.from(0),
+    deadline: 5,
+    validationContract: ethers.constants.AddressZero,
+    validationData: data,
+  };
+}

--- a/src/order/validation.ts
+++ b/src/order/validation.ts
@@ -1,0 +1,58 @@
+import { ethers } from "ethers";
+
+import { OrderInfo } from "./types";
+
+export enum ValidationType {
+  None,
+  ExclusiveFiller,
+}
+
+type ExclusiveFillerData = {
+  filler: string;
+  lastExclusiveTimestamp: number;
+};
+
+export type CustomOrderValidation =
+  | {
+      type: ValidationType.None;
+      data: null;
+    }
+  | {
+      type: ValidationType.ExclusiveFiller;
+      data: ExclusiveFillerData;
+    };
+
+const NONE_VALIDATION: CustomOrderValidation = {
+  type: ValidationType.None,
+  data: null,
+};
+
+export function parseValidation(info: OrderInfo): CustomOrderValidation {
+  // TODO: extend to support multiple validation types
+  // Add mapping of address to validation type, if no matches iterate through attempting to parse
+  const data = parseExclusiveFillerData(info.validationData);
+  if (data.type !== ValidationType.None) {
+    return data;
+  }
+
+  return NONE_VALIDATION;
+}
+
+// returns decoded filler data, or null if invalid encoding
+function parseExclusiveFillerData(encoded: string): CustomOrderValidation {
+  try {
+    const [address, timestamp] = new ethers.utils.AbiCoder().decode(
+      ["address", "uint256"],
+      encoded
+    );
+    return {
+      type: ValidationType.ExclusiveFiller,
+      data: {
+        filler: address,
+        lastExclusiveTimestamp: timestamp.toNumber(),
+      },
+    };
+  } catch {
+    return NONE_VALIDATION;
+  }
+}

--- a/src/utils/OrderQuoter.ts
+++ b/src/utils/OrderQuoter.ts
@@ -8,7 +8,7 @@ import {
   OrderQuoter as OrderQuoterContract,
 } from "../contracts";
 import { MissingConfiguration } from "../errors";
-import { IOrder, TokenAmount } from "../order";
+import { Order, TokenAmount } from "../order";
 
 import { NonceManager } from "./NonceManager";
 import { multicall, MulticallResult } from "./multicall";
@@ -53,7 +53,7 @@ const KNOWN_ERRORS: { [key: string]: OrderValidation } = {
 };
 
 export interface SignedOrder {
-  order: IOrder;
+  order: Order;
   signature: string;
 }
 


### PR DESCRIPTION
This commit adds handling for custom order validation parsing. Currently
we only have the exclusive filler validation but kept it extensible for
when we add new validation types in the future

Closes #18
