### PR TITLE
fix: add NonceUsed prefix

### DIFF
--- a/src/utils/OrderQuoter.ts
+++ b/src/utils/OrderQuoter.ts
@@ -107,12 +107,8 @@ export class OrderQuoter {
       functionParams: calls,
     });
 
-    console.log(JSON.stringify(results, null, 2));
-
     const validations = await this.getValidations(orders, results);
 
-    console.log("validations in quoter");
-    console.log(JSON.stringify(validations, null, 2));
     const quotes: (ResolvedOrder | undefined)[] = results.map(
       ({ success, returnData }) => {
         if (!success) {


### PR DESCRIPTION
https://etherscan.io/tx/0x4a8ab63a21655d9d79ef147ca7e0df58057439e79bc0e4696e450dfd6a383124 this is filled but 
```
    const results = await multicallSameContractManyFunctions(this.provider, {
      address: this.orderQuoter.address,
      contractInterface: this.orderQuoter.interface,
      functionName: "quote",
      functionParams: calls,
    });
``` 
gives

```
  [
    false,
    "0x70f65caa"
  ]
```