### PR TITLE
chore: rename DutchLimitOrder* -> DutchOrder*

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The SDK contains bindings for two main flows: parsing serialized orders & buildi
 ### Building & Signing Orders
 
 ```ts
-import { DutchLimitOrder, NonceManager } from '@uniswap/gouda-sdk';
+import { DutchOrder, NonceManager } from '@uniswap/gouda-sdk';
 import { ethers } from 'ethers';
 
 const provider = new ethers.providers.JsonRpcProvider(RPC_URL);
@@ -18,7 +18,7 @@ const nonceMgr = new NonceManager(provider, 1);
 const nonce = await nonceMgr.useNonce(account); 
 
 const chainId = 1;
-const builder = new DutchLimitOrderBuilder(chainId);
+const builder = new DutchOrderBuilder(chainId);
 const order = builder
   .deadline(deadline)
   .endTime(deadline)

--- a/integration/test/DutchLimitOrder.spec.ts
+++ b/integration/test/DutchLimitOrder.spec.ts
@@ -13,9 +13,9 @@ import {
   DutchLimitOrderReactor,
   MockERC20,
 } from '../../src/contracts';
-import { DutchLimitOrderBuilder } from '../../';
+import { DutchOrderBuilder } from '../../';
 
-describe('DutchLimitOrder', () => {
+describe('DutchOrder', () => {
   const DIRECT_TAKER_FILL = '0x0000000000000000000000000000000000000001';
 
   let reactor: DutchLimitOrderReactor;
@@ -82,7 +82,7 @@ describe('DutchLimitOrder', () => {
     const amount = BigNumber.from(10).pow(18);
     const deadline = await new BlockchainTime().secondsFromNow(1000);
     const makerAddress = await maker.getAddress();
-    const preBuildOrder = new DutchLimitOrderBuilder(
+    const preBuildOrder = new DutchOrderBuilder(
       chainId,
       reactor.address,
       permit2.address
@@ -131,7 +131,7 @@ describe('DutchLimitOrder', () => {
   it('executes a serialized order with no decay', async () => {
     const amount = BigNumber.from(10).pow(18);
     const deadline = await new BlockchainTime().secondsFromNow(1000);
-    const order = new DutchLimitOrderBuilder(
+    const order = new DutchOrderBuilder(
       chainId,
       reactor.address,
       permit2.address
@@ -197,7 +197,7 @@ describe('DutchLimitOrder', () => {
     const amount = BigNumber.from(10).pow(18);
     const time = new BlockchainTime();
     const deadline = await time.secondsFromNow(1000);
-    const order = new DutchLimitOrderBuilder(
+    const order = new DutchOrderBuilder(
       chainId,
       reactor.address,
       permit2.address

--- a/integration/test/EventWatcher.ts
+++ b/integration/test/EventWatcher.ts
@@ -14,7 +14,7 @@ import {
   DutchLimitOrderReactor,
   MockERC20,
 } from "../../src/contracts";
-import { DutchLimitOrderBuilder, EventWatcher, FillData } from "../../";
+import { DutchOrderBuilder, EventWatcher, FillData } from "../../";
 
 describe("EventWatcher", () => {
   let reactor: DutchLimitOrderReactor;
@@ -85,7 +85,7 @@ describe("EventWatcher", () => {
   it("Fetches fill events", async () => {
     const amount = BigNumber.from(10).pow(18);
     const deadline = await new BlockchainTime().secondsFromNow(1000);
-    const order = new DutchLimitOrderBuilder(
+    const order = new DutchOrderBuilder(
       chainId,
       reactor.address,
       permit2.address
@@ -142,7 +142,7 @@ describe("EventWatcher", () => {
   it("Handles callbacks on fill events", async () => {
     const amount = BigNumber.from(10).pow(18);
     const deadline = await new BlockchainTime().secondsFromNow(1000);
-    const order = new DutchLimitOrderBuilder(
+    const order = new DutchOrderBuilder(
       chainId,
       reactor.address,
       permit2.address

--- a/integration/test/OrderValidator.spec.ts
+++ b/integration/test/OrderValidator.spec.ts
@@ -17,8 +17,8 @@ import {
   MockERC20,
 } from "../../src/contracts";
 import {
-  DutchLimitOrderBuilder,
-  DutchLimitOrder,
+  DutchOrderBuilder,
+  DutchOrder,
   OrderValidator,
   OrderQuoter as OrderQuoterLib,
   OrderValidation,
@@ -37,7 +37,7 @@ describe("OrderValidator", () => {
   let permit2: Permit2;
   let quoter: OrderQuoter;
   let chainId: number;
-  let builder: DutchLimitOrderBuilder;
+  let builder: DutchOrderBuilder;
   let validator: OrderValidator;
   let tokenIn: MockERC20;
   let tokenOut: MockERC20;
@@ -75,7 +75,7 @@ describe("OrderValidator", () => {
     );
     quoter = (await orderQuoterFactory.deploy()) as OrderQuoter;
     chainId = hre.network.config.chainId || 1;
-    builder = new DutchLimitOrderBuilder(
+    builder = new DutchOrderBuilder(
       chainId,
       reactor.address,
       permit2.address
@@ -444,7 +444,7 @@ describe("OrderValidator", () => {
       endAmount: BigNumber.from("20000000000000000000"),
     });
 
-    const order = new DutchLimitOrder(
+    const order = new DutchOrder(
       Object.assign(info, { outputs: [output] }),
       chainId,
       permit2.address
@@ -478,7 +478,7 @@ describe("OrderValidator", () => {
         recipient: "0x0000000000000000000000000000000000000000",
       })
       .build().info;
-    const order = new DutchLimitOrder(
+    const order = new DutchOrder(
       Object.assign(info, {
         deadline: deadline - 100,
         endTime: deadline - 100,
@@ -517,7 +517,7 @@ describe("OrderValidator", () => {
       })
       .build().info;
 
-    const order = new DutchLimitOrder(info, chainId, permit2.address);
+    const order = new DutchOrder(info, chainId, permit2.address);
 
     const { domain, types, values } = order.permitData();
     const signature = await maker._signTypedData(domain, types, values);
@@ -561,7 +561,7 @@ describe("OrderValidator", () => {
         recipient: "0x0000000000000000000000000000000000000000",
       })
       .build().info;
-    const order = new DutchLimitOrder(
+    const order = new DutchOrder(
       Object.assign(info, { endTime: deadline - 100 }),
       chainId,
       permit2.address
@@ -595,7 +595,7 @@ describe("OrderValidator", () => {
         recipient: "0x0000000000000000000000000000000000000000",
       })
       .build().info;
-    const order = new DutchLimitOrder(info, chainId, permit2.address);
+    const order = new DutchOrder(info, chainId, permit2.address);
 
     const { domain, types, values } = order.permitData();
     const signature = await maker._signTypedData(domain, types, values);

--- a/src/builder/DutchOrderBuilder.test.ts
+++ b/src/builder/DutchOrderBuilder.test.ts
@@ -1,15 +1,15 @@
 import { BigNumber } from "ethers";
 
-import { DutchLimitOrder } from "../order/DutchLimitOrder";
+import { DutchOrder } from "../order/DutchOrder";
 import { encodeExclusiveFillerData, ValidationType } from "../order/validation";
 
-import { DutchLimitOrderBuilder } from "./DutchLimitOrderBuilder";
+import { DutchOrderBuilder } from "./DutchOrderBuilder";
 
-describe("DutchLimitOrderBuilder", () => {
-  let builder: DutchLimitOrderBuilder;
+describe("DutchOrderBuilder", () => {
+  let builder: DutchOrderBuilder;
 
   beforeEach(() => {
-    builder = new DutchLimitOrderBuilder(1);
+    builder = new DutchOrderBuilder(1);
   });
 
   it("Builds a valid order", () => {
@@ -110,7 +110,7 @@ describe("DutchLimitOrderBuilder", () => {
       })
       .build();
 
-    const regenerated = DutchLimitOrderBuilder.fromOrder(order).build();
+    const regenerated = DutchOrderBuilder.fromOrder(order).build();
     expect(regenerated.toJSON()).toMatchObject(order.toJSON());
   });
 
@@ -146,8 +146,8 @@ describe("DutchLimitOrderBuilder", () => {
       .build();
 
     const json = order.toJSON();
-    const regenerated = DutchLimitOrderBuilder.fromOrder(
-      DutchLimitOrder.fromJSON(json, 1)
+    const regenerated = DutchOrderBuilder.fromOrder(
+      DutchOrder.fromJSON(json, 1)
     ).build();
     expect(regenerated.toJSON()).toMatchObject(order.toJSON());
   });
@@ -183,7 +183,7 @@ describe("DutchLimitOrderBuilder", () => {
       })
       .build();
 
-    const regenerated = DutchLimitOrderBuilder.fromOrder(order)
+    const regenerated = DutchOrderBuilder.fromOrder(order)
       .startTime(order.info.startTime + 1)
       .build();
     expect(regenerated.info.startTime).toEqual(order.info.startTime + 1);
@@ -309,7 +309,7 @@ describe("DutchLimitOrderBuilder", () => {
 
   it("Unknown chainId", () => {
     const chainId = 99999999;
-    expect(() => new DutchLimitOrderBuilder(chainId)).toThrow(
+    expect(() => new DutchOrderBuilder(chainId)).toThrow(
       `Missing configuration for reactor: ${chainId}`
     );
   });

--- a/src/builder/DutchOrderBuilder.ts
+++ b/src/builder/DutchOrderBuilder.ts
@@ -3,12 +3,7 @@ import invariant from "tiny-invariant";
 
 import { OrderType, REACTOR_ADDRESS_MAPPING } from "../constants";
 import { MissingConfiguration } from "../errors";
-import {
-  DutchInput,
-  DutchLimitOrder,
-  DutchLimitOrderInfo,
-  DutchOutput,
-} from "../order";
+import { DutchInput, DutchOrder, DutchOrderInfo, DutchOutput } from "../order";
 import { ValidationInfo } from "../order/validation";
 
 import { OrderBuilder } from "./OrderBuilder";
@@ -16,15 +11,12 @@ import { OrderBuilder } from "./OrderBuilder";
 /**
  * Helper builder for generating dutch limit orders
  */
-export class DutchLimitOrderBuilder extends OrderBuilder {
-  private info: Partial<DutchLimitOrderInfo>;
+export class DutchOrderBuilder extends OrderBuilder {
+  private info: Partial<DutchOrderInfo>;
 
-  static fromOrder(order: DutchLimitOrder): DutchLimitOrderBuilder {
+  static fromOrder(order: DutchOrder): DutchOrderBuilder {
     // note chainId not used if passing in true reactor address
-    const builder = new DutchLimitOrderBuilder(
-      order.chainId,
-      order.info.reactor
-    )
+    const builder = new DutchOrderBuilder(order.chainId, order.info.reactor)
       .deadline(order.info.deadline)
       .endTime(order.info.endTime)
       .startTime(order.info.startTime)
@@ -57,10 +49,9 @@ export class DutchLimitOrderBuilder extends OrderBuilder {
       this.reactor(reactorAddress);
     } else if (
       REACTOR_ADDRESS_MAPPING[chainId] &&
-      REACTOR_ADDRESS_MAPPING[chainId][OrderType.DutchLimit]
+      REACTOR_ADDRESS_MAPPING[chainId][OrderType.Dutch]
     ) {
-      const reactorAddress =
-        REACTOR_ADDRESS_MAPPING[chainId][OrderType.DutchLimit];
+      const reactorAddress = REACTOR_ADDRESS_MAPPING[chainId][OrderType.Dutch];
       this.reactor(reactorAddress);
     } else {
       throw new MissingConfiguration("reactor", chainId.toString());
@@ -73,12 +64,12 @@ export class DutchLimitOrderBuilder extends OrderBuilder {
     };
   }
 
-  startTime(startTime: number): DutchLimitOrderBuilder {
+  startTime(startTime: number): DutchOrderBuilder {
     this.info.startTime = startTime;
     return this;
   }
 
-  endTime(endTime: number): DutchLimitOrderBuilder {
+  endTime(endTime: number): DutchOrderBuilder {
     if (this.orderInfo.deadline === undefined) {
       super.deadline(endTime);
     }
@@ -87,12 +78,12 @@ export class DutchLimitOrderBuilder extends OrderBuilder {
     return this;
   }
 
-  input(input: DutchInput): DutchLimitOrderBuilder {
+  input(input: DutchInput): DutchOrderBuilder {
     this.info.input = input;
     return this;
   }
 
-  output(output: DutchOutput): DutchLimitOrderBuilder {
+  output(output: DutchOutput): DutchOrderBuilder {
     if (!this.info.outputs) {
       this.info.outputs = [];
     }
@@ -104,7 +95,7 @@ export class DutchLimitOrderBuilder extends OrderBuilder {
     return this;
   }
 
-  deadline(deadline: number): DutchLimitOrderBuilder {
+  deadline(deadline: number): DutchOrderBuilder {
     super.deadline(deadline);
 
     if (this.info.endTime === undefined) {
@@ -114,23 +105,23 @@ export class DutchLimitOrderBuilder extends OrderBuilder {
     return this;
   }
 
-  offerer(offerer: string): DutchLimitOrderBuilder {
+  offerer(offerer: string): DutchOrderBuilder {
     super.offerer(offerer);
     return this;
   }
 
-  nonce(nonce: BigNumber): DutchLimitOrderBuilder {
+  nonce(nonce: BigNumber): DutchOrderBuilder {
     super.nonce(nonce);
     return this;
   }
 
-  validation(info: ValidationInfo): DutchLimitOrderBuilder {
+  validation(info: ValidationInfo): DutchOrderBuilder {
     super.validation(info);
     return this;
   }
 
   // ensures that we only change non fee outputs
-  nonFeeRecipient(recipient: string): DutchLimitOrderBuilder {
+  nonFeeRecipient(recipient: string): DutchOrderBuilder {
     if (!this.info.outputs) {
       return this;
     }
@@ -144,13 +135,13 @@ export class DutchLimitOrderBuilder extends OrderBuilder {
   exclusiveFiller(
     exclusiveFiller: string,
     exclusivityOverrideBps: BigNumber
-  ): DutchLimitOrderBuilder {
+  ): DutchOrderBuilder {
     this.info.exclusiveFiller = exclusiveFiller;
     this.info.exclusivityOverrideBps = exclusivityOverrideBps;
     return this;
   }
 
-  build(): DutchLimitOrder {
+  build(): DutchOrder {
     invariant(this.info.startTime !== undefined, "startTime not set");
     invariant(this.info.input !== undefined, "input not set");
     invariant(this.info.endTime !== undefined, "endTime not set");
@@ -181,7 +172,7 @@ export class DutchLimitOrderBuilder extends OrderBuilder {
       `endTime must be before or same as deadline: ${this.info.endTime}`
     );
 
-    return new DutchLimitOrder(
+    return new DutchOrder(
       Object.assign(this.getOrderInfo(), {
         startTime: this.info.startTime,
         endTime: this.info.endTime,

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -1,2 +1,2 @@
-export * from "./DutchLimitOrderBuilder";
+export * from "./DutchOrderBuilder";
 export * from "./OrderBuilder";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export enum KNOWN_EVENT_SIGNATURES {
 }
 
 export enum OrderType {
-  DutchLimit = "DutchLimit",
+  Dutch = "Dutch",
 }
 
 type Reactors = {
@@ -39,16 +39,16 @@ type ReverseReactorMapping = {
 
 export const REACTOR_ADDRESS_MAPPING: ReactorMapping = {
   1: {
-    [OrderType.DutchLimit]: "0xbD7F9D0239f81C94b728d827a87b9864972661eC",
+    [OrderType.Dutch]: "0xbD7F9D0239f81C94b728d827a87b9864972661eC",
   },
   5: {
-    [OrderType.DutchLimit]: "0xE5D50eB6e669C32D797379aF3907478FE491036D",
+    [OrderType.Dutch]: "0xE5D50eB6e669C32D797379aF3907478FE491036D",
   },
   137: {
-    [OrderType.DutchLimit]: "0xbD7F9D0239f81C94b728d827a87b9864972661eC",
+    [OrderType.Dutch]: "0xbD7F9D0239f81C94b728d827a87b9864972661eC",
   },
   12341234: {
-    [OrderType.DutchLimit]: "0xFF086b7696Dc4116B336Dd0e42ecd2164FC2712B",
+    [OrderType.Dutch]: "0xFF086b7696Dc4116B336Dd0e42ecd2164FC2712B",
   },
 };
 

--- a/src/order/DutchOrder.test.ts
+++ b/src/order/DutchOrder.test.ts
@@ -1,11 +1,9 @@
 import { BigNumber, ethers } from "ethers";
 
-import { DutchLimitOrder, DutchLimitOrderInfo } from "./DutchLimitOrder";
+import { DutchOrder, DutchOrderInfo } from "./DutchOrder";
 
-describe("DutchLimitOrder", () => {
-  const getOrderInfo = (
-    data: Partial<DutchLimitOrderInfo>
-  ): DutchLimitOrderInfo => {
+describe("DutchOrder", () => {
+  const getOrderInfo = (data: Partial<DutchOrderInfo>): DutchOrderInfo => {
     return Object.assign(
       {
         deadline: Math.floor(new Date().getTime() / 1000) + 1000,
@@ -38,14 +36,14 @@ describe("DutchLimitOrder", () => {
 
   it("parses a serialized order", () => {
     const orderInfo = getOrderInfo({});
-    const order = new DutchLimitOrder(orderInfo, 1);
+    const order = new DutchOrder(orderInfo, 1);
     const serialized = order.serialize();
-    const parsed = DutchLimitOrder.parse(serialized, 1);
+    const parsed = DutchOrder.parse(serialized, 1);
     expect(parsed.info).toEqual(orderInfo);
   });
 
   it("valid signature over info", async () => {
-    const order = new DutchLimitOrder(getOrderInfo({}), 1);
+    const order = new DutchOrder(getOrderInfo({}), 1);
     const wallet = ethers.Wallet.createRandom();
 
     const { domain, types, values } = order.permitData();

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -2,10 +2,10 @@ import { OrderType, REVERSE_REACTOR_MAPPING } from "../constants";
 import { MissingConfiguration } from "../errors";
 import { stripHexPrefix } from "../utils";
 
-import { DutchLimitOrder } from "./DutchLimitOrder";
+import { DutchOrder } from "./DutchOrder";
 import { Order } from "./types";
 
-export * from "./DutchLimitOrder";
+export * from "./DutchOrder";
 export * from "./types";
 export * from "./validation";
 
@@ -30,8 +30,8 @@ export function parseOrder(order: string): Order {
 
   const { chainId, orderType } = REVERSE_REACTOR_MAPPING[reactor];
   switch (orderType) {
-    case OrderType.DutchLimit:
-      return DutchLimitOrder.parse(order, chainId);
+    case OrderType.Dutch:
+      return DutchOrder.parse(order, chainId);
     default:
       throw new MissingConfiguration("orderType", orderType);
   }

--- a/src/trade/DutchOrderTrade.test.ts
+++ b/src/trade/DutchOrderTrade.test.ts
@@ -1,9 +1,9 @@
 import { Currency, Token, TradeType } from "@uniswap/sdk-core";
 import { BigNumber, ethers } from "ethers";
 
-import { DutchLimitOrderInfo } from "../order";
+import { DutchOrderInfo } from "../order";
 
-import { DutchLimitOrderTrade } from "./DutchLimitOrderTrade";
+import { DutchOrderTrade } from "./DutchOrderTrade";
 
 const USDC = new Token(
   1,
@@ -18,11 +18,11 @@ const DAI = new Token(
   "DAI"
 );
 
-describe("DutchLimitOrderTrade", () => {
+describe("DutchOrderTrade", () => {
   const NON_FEE_OUTPUT_AMOUNT = BigNumber.from("1000000000000000000");
   const NON_FEE_MINIMUM_AMOUNT_OUT = BigNumber.from("900000000000000000");
 
-  const orderInfo: DutchLimitOrderInfo = {
+  const orderInfo: DutchOrderInfo = {
     deadline: Math.floor(new Date().getTime() / 1000) + 1000,
     reactor: "0x0000000000000000000000000000000000000000",
     offerer: "0x0000000000000000000000000000000000000000",
@@ -54,7 +54,7 @@ describe("DutchLimitOrderTrade", () => {
     ],
   };
 
-  const trade = new DutchLimitOrderTrade<Currency, Currency, TradeType>({
+  const trade = new DutchOrderTrade<Currency, Currency, TradeType>({
     currencyIn: USDC,
     currenciesOut: [DAI],
     orderInfo,

--- a/src/trade/DutchOrderTrade.ts
+++ b/src/trade/DutchOrderTrade.ts
@@ -1,16 +1,16 @@
 import { Currency, CurrencyAmount, Price, TradeType } from "@uniswap/sdk-core";
 
-import { DutchLimitOrder, DutchLimitOrderInfo } from "../order";
+import { DutchOrder, DutchOrderInfo } from "../order";
 
 import { areCurrenciesEqual } from "./utils";
 
-export class DutchLimitOrderTrade<
+export class DutchOrderTrade<
   TInput extends Currency,
   TOutput extends Currency,
   TTradeType extends TradeType
 > {
   public readonly tradeType: TTradeType;
-  public readonly order: DutchLimitOrder;
+  public readonly order: DutchOrder;
 
   private _inputAmount: CurrencyAmount<TInput> | undefined;
   private _outputAmounts: CurrencyAmount<TOutput>[] | undefined;
@@ -26,7 +26,7 @@ export class DutchLimitOrderTrade<
   }: {
     currencyIn: TInput;
     currenciesOut: TOutput[];
-    orderInfo: DutchLimitOrderInfo;
+    orderInfo: DutchOrderInfo;
     tradeType: TTradeType;
   }) {
     this._currencyIn = currencyIn;
@@ -34,7 +34,7 @@ export class DutchLimitOrderTrade<
     this.tradeType = tradeType;
 
     // assume single-chain for now
-    this.order = new DutchLimitOrder(orderInfo, currencyIn.chainId);
+    this.order = new DutchOrder(orderInfo, currencyIn.chainId);
   }
 
   public get inputAmount(): CurrencyAmount<TInput> {

--- a/src/trade/index.ts
+++ b/src/trade/index.ts
@@ -1,1 +1,1 @@
-export * from "./DutchLimitOrderTrade";
+export * from "./DutchOrderTrade";

--- a/src/trade/utils.ts
+++ b/src/trade/utils.ts
@@ -7,11 +7,11 @@ export function areCurrenciesEqual(
 ) {
   if (currency.chainId !== chainId) return false;
 
-  // TODO: once native currencies are supported by dutch limit order trades, add handling based on
+  // TODO: once native currencies are supported by dutch order trades, add handling based on
   // shared native currency address format
   if (currency.isNative) {
     throw new Error(
-      "native currencies are not currently supported by DutchLimitOrder trades"
+      "native currencies are not currently supported by DutchOrder trades"
     );
   }
 


### PR DESCRIPTION
- renamed most instances of `DutchLimitOrder*` to `DutchOrder*` 
- left the contract/ABI stuff alone since i assume some of that is auto-generated
- left the `ExclusiveDutchLimitOrder` in the signed typed data struct as is in case there's any on-chain changes we need to make first 🤔 