### PR TITLE
feat: Support for native currencies in DutchOrderTrade

### DIFF
--- a/src/trade/DutchOrderTrade.test.ts
+++ b/src/trade/DutchOrderTrade.test.ts
@@ -1,9 +1,10 @@
-import { Currency, Token, TradeType } from "@uniswap/sdk-core";
+import { Currency, Ether,  Token, TradeType } from "@uniswap/sdk-core";
 import { BigNumber, ethers } from "ethers";
 
 import { DutchOrderInfo } from "../order";
 
 import { DutchOrderTrade } from "./DutchOrderTrade";
+import { NativeAssets } from "./utils";
 
 const USDC = new Token(
   1,
@@ -78,4 +79,25 @@ describe("DutchOrderTrade", () => {
       NON_FEE_MINIMUM_AMOUNT_OUT.toString()
     );
   });
+
+  it("works for native output trades", () => {
+    const ethOutputOrderInfo = {
+      ...orderInfo,
+      outputs: [
+        {
+          token: NativeAssets.ETH,
+          startAmount: NON_FEE_OUTPUT_AMOUNT,
+          endAmount: NON_FEE_MINIMUM_AMOUNT_OUT,
+          recipient: "0x0000000000000000000000000000000000000000",
+        },
+      ],
+    }
+    const ethOutputTrade = new DutchOrderTrade<Currency, Currency, TradeType>({
+      currencyIn: USDC,
+      currenciesOut: [Ether.onChain(1)],
+      orderInfo: ethOutputOrderInfo,
+      tradeType: TradeType.EXACT_INPUT,
+    });
+    expect(ethOutputTrade.outputAmount.currency).toEqual(Ether.onChain(1))
+  })
 });

--- a/src/trade/utils.ts
+++ b/src/trade/utils.ts
@@ -1,4 +1,24 @@
-import { Currency } from "@uniswap/sdk-core";
+import { ChainId, Currency } from "@uniswap/sdk-core";
+
+export enum NativeAssets {
+  MATIC = 'MATIC',
+  BNB = 'BNB',
+  AVAX = 'AVAX',
+  ETH = 'ETH',
+}
+
+function nativeCurrencyAddressString(chainId: number): string {
+  switch (chainId) {
+    case ChainId.POLYGON:
+      return NativeAssets.MATIC 
+    case ChainId.BNB:
+      return NativeAssets.BNB 
+    case ChainId.AVALANCHE:
+      return NativeAssets.AVAX
+    default:
+      return NativeAssets.ETH
+  }
+}
 
 export function areCurrenciesEqual(
   currency: Currency,
@@ -7,12 +27,8 @@ export function areCurrenciesEqual(
 ) {
   if (currency.chainId !== chainId) return false;
 
-  // TODO: once native currencies are supported by dutch order trades, add handling based on
-  // shared native currency address format
   if (currency.isNative) {
-    throw new Error(
-      "native currencies are not currently supported by DutchOrder trades"
-    );
+    return address === nativeCurrencyAddressString(chainId)
   }
 
   return currency.address.toLowerCase() === address?.toLowerCase();


### PR DESCRIPTION
these are the same token addresses the Uniswap interface will pass in to the trade object:

https://github.com/Uniswap/interface/blob/main/src/state/routing/utils.ts#L309

and 

https://github.com/Uniswap/interface/blob/main/src/state/routing/utils.ts#L150