### PR TITLE
fix: use zero address for native token checks

### DIFF
--- a/src/trade/DutchOrderTrade.test.ts
+++ b/src/trade/DutchOrderTrade.test.ts
@@ -1,10 +1,10 @@
-import { Currency, Ether,  Token, TradeType } from "@uniswap/sdk-core";
+import { Currency, Ether, Token, TradeType } from "@uniswap/sdk-core";
 import { BigNumber, ethers } from "ethers";
 
 import { DutchOrderInfo } from "../order";
 
 import { DutchOrderTrade } from "./DutchOrderTrade";
-import { NativeAssets } from "./utils";
+import { NATIVE_ADDRESS } from "./utils";
 
 const USDC = new Token(
   1,
@@ -85,19 +85,19 @@ describe("DutchOrderTrade", () => {
       ...orderInfo,
       outputs: [
         {
-          token: NativeAssets.ETH,
+          token: NATIVE_ADDRESS,
           startAmount: NON_FEE_OUTPUT_AMOUNT,
           endAmount: NON_FEE_MINIMUM_AMOUNT_OUT,
           recipient: "0x0000000000000000000000000000000000000000",
         },
       ],
-    }
+    };
     const ethOutputTrade = new DutchOrderTrade<Currency, Currency, TradeType>({
       currencyIn: USDC,
       currenciesOut: [Ether.onChain(1)],
       orderInfo: ethOutputOrderInfo,
       tradeType: TradeType.EXACT_INPUT,
     });
-    expect(ethOutputTrade.outputAmount.currency).toEqual(Ether.onChain(1))
-  })
+    expect(ethOutputTrade.outputAmount.currency).toEqual(Ether.onChain(1));
+  });
 });

--- a/src/trade/utils.ts
+++ b/src/trade/utils.ts
@@ -1,24 +1,6 @@
-import { ChainId, Currency } from "@uniswap/sdk-core";
+import { Currency } from "@uniswap/sdk-core";
 
-export enum NativeAssets {
-  MATIC = 'MATIC',
-  BNB = 'BNB',
-  AVAX = 'AVAX',
-  ETH = 'ETH',
-}
-
-function nativeCurrencyAddressString(chainId: number): string {
-  switch (chainId) {
-    case ChainId.POLYGON:
-      return NativeAssets.MATIC 
-    case ChainId.BNB:
-      return NativeAssets.BNB 
-    case ChainId.AVALANCHE:
-      return NativeAssets.AVAX
-    default:
-      return NativeAssets.ETH
-  }
-}
+export const NATIVE_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export function areCurrenciesEqual(
   currency: Currency,
@@ -28,7 +10,7 @@ export function areCurrenciesEqual(
   if (currency.chainId !== chainId) return false;
 
   if (currency.isNative) {
-    return address === nativeCurrencyAddressString(chainId)
+    return address === NATIVE_ADDRESS;
   }
 
   return currency.address.toLowerCase() === address?.toLowerCase();


### PR DESCRIPTION
## Summary
We are using the zero address for native token out swaps.