### PR TITLE
chore: remove module field in pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
       "pre-commit": "yarn fix"
     }
   },
-  "module": "dist/uniswapx-sdk.esm.js",
   "devDependencies": {
     "@typechain/ethers-v5": "^10.1.0",
     "@types/jest": "^29.0.3",


### PR DESCRIPTION
the bundle files have no esm module file. So remove this field.