### PR TITLE
feat: add multiple cancel params

### DIFF
--- a/src/utils/NonceManager.test.ts
+++ b/src/utils/NonceManager.test.ts
@@ -2,6 +2,7 @@ import { BigNumber, ethers } from "ethers";
 
 import {
   buildNonce,
+  getCancelMultipleParams,
   getCancelSingleParams,
   getFirstUnsetBit,
   setBit,
@@ -149,6 +150,56 @@ describe("NonceManager", () => {
       expect(
         getCancelSingleParams(BigNumber.from(257)).mask.toString()
       ).toEqual("2");
+    });
+  });
+
+  describe("getCancelMultipleParams", () => {
+    it("0, 1", () => {
+      expect(
+        getCancelMultipleParams([BigNumber.from(0), BigNumber.from(1)]).length
+      ).toEqual(1);
+      expect(
+        getCancelMultipleParams([
+          BigNumber.from(0),
+          BigNumber.from(1),
+        ])[0].word.toString()
+      ).toEqual("0");
+      expect(
+        getCancelMultipleParams([
+          BigNumber.from(0),
+          BigNumber.from(1),
+        ])[0].mask.toString()
+      ).toEqual("3");
+    });
+
+    it("0, 256", () => {
+      expect(
+        getCancelMultipleParams([BigNumber.from(0), BigNumber.from(256)]).length
+      ).toEqual(2);
+      expect(
+        getCancelMultipleParams([
+          BigNumber.from(0),
+          BigNumber.from(256),
+        ])[0].word.toString()
+      ).toEqual("0");
+      expect(
+        getCancelMultipleParams([
+          BigNumber.from(0),
+          BigNumber.from(256),
+        ])[1].word.toString()
+      ).toEqual("1");
+      expect(
+        getCancelMultipleParams([
+          BigNumber.from(0),
+          BigNumber.from(256),
+        ])[0].mask.toString()
+      ).toEqual("1");
+      expect(
+        getCancelMultipleParams([
+          BigNumber.from(0),
+          BigNumber.from(256),
+        ])[1].mask.toString()
+      ).toEqual("1");
     });
   });
 });

--- a/src/utils/NonceManager.ts
+++ b/src/utils/NonceManager.ts
@@ -139,3 +139,25 @@ export function getCancelSingleParams(nonceToCancel: BigNumber): CancelParams {
   const mask = BigNumber.from(2).pow(bitPos);
   return { word, mask };
 }
+
+// Get parameters to cancel multiple nonces
+export function getCancelMultipleParams(
+  noncesToCancel: BigNumber[]
+): CancelParams[] {
+  const splitNonces = noncesToCancel.map(splitNonce);
+  const splitNoncesByWord: { [word: string]: SplitNonce[] } = {};
+  splitNonces.forEach((splitNonce) => {
+    const word = splitNonce.word.toString();
+    if (!splitNoncesByWord[word]) {
+      splitNoncesByWord[word] = [];
+    }
+    splitNoncesByWord[word].push(splitNonce);
+  });
+  return Object.entries(splitNoncesByWord).map(([word, splitNonce]) => {
+    let mask = BigNumber.from(0);
+    splitNonce.forEach((splitNonce) => {
+      mask = mask.or(BigNumber.from(2).pow(splitNonce.bitPos));
+    });
+    return { word: BigNumber.from(word), mask };
+  });
+}


### PR DESCRIPTION
This commit adds a helper function for getting the cancel params for
canceling multiple nonces at once. It just groups the nonces by word and
bitwise ORs the masks for each cancelation to get the minimal set of
calls. An integrator should take each CancelParams and use it to call
the invalidateUnorderedNonces function on permit2
