### PR TITLE
feat: update generic order parser for v2

### DIFF
--- a/src/builder/V2DutchOrderBuilder.test.ts
+++ b/src/builder/V2DutchOrderBuilder.test.ts
@@ -8,7 +8,7 @@ import { V2DutchOrderBuilder } from "./V2DutchOrderBuilder";
 const INPUT_TOKEN = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 const OUTPUT_TOKEN = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
 
-const INTPUT_START_AMOUNT = BigNumber.from("1000000");
+const INPUT_START_AMOUNT = BigNumber.from("1000000");
 const OUTPUT_START_AMOUNT = BigNumber.from("1000000000000000000");
 
 describe("V2DutchOrderBuilder", () => {
@@ -30,8 +30,8 @@ describe("V2DutchOrderBuilder", () => {
       .nonce(BigNumber.from(100))
       .input({
         token: INPUT_TOKEN,
-        startAmount: INTPUT_START_AMOUNT,
-        endAmount: INTPUT_START_AMOUNT,
+        startAmount: INPUT_START_AMOUNT,
+        endAmount: INPUT_START_AMOUNT,
       })
       .output({
         token: OUTPUT_TOKEN,
@@ -39,7 +39,7 @@ describe("V2DutchOrderBuilder", () => {
         endAmount: OUTPUT_START_AMOUNT.mul(90).div(100),
         recipient: constants.AddressZero,
       })
-      .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+      .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
       .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
       .build();
 
@@ -69,8 +69,8 @@ describe("V2DutchOrderBuilder", () => {
       .nonce(BigNumber.from(100))
       .input({
         token: INPUT_TOKEN,
-        startAmount: INTPUT_START_AMOUNT,
-        endAmount: INTPUT_START_AMOUNT,
+        startAmount: INPUT_START_AMOUNT,
+        endAmount: INPUT_START_AMOUNT,
       })
       .output({
         token: OUTPUT_TOKEN,
@@ -78,7 +78,7 @@ describe("V2DutchOrderBuilder", () => {
         endAmount: OUTPUT_START_AMOUNT.mul(90).div(100),
         recipient: constants.AddressZero,
       })
-      .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+      .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
       .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
       .validation(validationInfo)
       .build();
@@ -116,8 +116,8 @@ describe("V2DutchOrderBuilder", () => {
       .nonce(BigNumber.from(100))
       .input({
         token: INPUT_TOKEN,
-        startAmount: INTPUT_START_AMOUNT,
-        endAmount: INTPUT_START_AMOUNT,
+        startAmount: INPUT_START_AMOUNT,
+        endAmount: INPUT_START_AMOUNT,
       })
       .output({
         token: OUTPUT_TOKEN,
@@ -125,7 +125,7 @@ describe("V2DutchOrderBuilder", () => {
         endAmount: OUTPUT_START_AMOUNT.mul(90).div(100),
         recipient: constants.AddressZero,
       })
-      .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+      .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
       .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
       .validation(validationInfo)
       .build();
@@ -159,8 +159,8 @@ describe("V2DutchOrderBuilder", () => {
       .nonce(BigNumber.from(100))
       .input({
         token: INPUT_TOKEN,
-        startAmount: INTPUT_START_AMOUNT,
-        endAmount: INTPUT_START_AMOUNT,
+        startAmount: INPUT_START_AMOUNT,
+        endAmount: INPUT_START_AMOUNT,
       })
       .output({
         token: OUTPUT_TOKEN,
@@ -168,7 +168,7 @@ describe("V2DutchOrderBuilder", () => {
         endAmount: OUTPUT_START_AMOUNT.mul(90).div(100),
         recipient: constants.AddressZero,
       })
-      .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+      .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
       .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
       .validation(validationInfo)
       .build();
@@ -193,8 +193,8 @@ describe("V2DutchOrderBuilder", () => {
       .nonce(BigNumber.from(100))
       .input({
         token: INPUT_TOKEN,
-        startAmount: INTPUT_START_AMOUNT,
-        endAmount: INTPUT_START_AMOUNT,
+        startAmount: INPUT_START_AMOUNT,
+        endAmount: INPUT_START_AMOUNT,
       })
       .output({
         token: OUTPUT_TOKEN,
@@ -208,7 +208,7 @@ describe("V2DutchOrderBuilder", () => {
         endAmount: OUTPUT_START_AMOUNT.mul(9).div(100),
         recipient: constants.AddressZero,
       })
-      .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+      .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
       .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
       .build();
 
@@ -228,8 +228,8 @@ describe("V2DutchOrderBuilder", () => {
         .nonce(BigNumber.from(100))
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -237,7 +237,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT,
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
         .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
         .build()
     ).toThrow("Invariant failed: cosigner not set");
@@ -255,8 +255,8 @@ describe("V2DutchOrderBuilder", () => {
         .nonce(BigNumber.from(100))
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -264,7 +264,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT,
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
         .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
         .build()
     ).toThrow("Invariant failed: swapper not set");
@@ -281,8 +281,8 @@ describe("V2DutchOrderBuilder", () => {
         .swapper(constants.AddressZero)
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -290,7 +290,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT,
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
         .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
         .build()
     ).toThrow("Invariant failed: deadline not set");
@@ -308,8 +308,8 @@ describe("V2DutchOrderBuilder", () => {
         .swapper(constants.AddressZero)
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -317,7 +317,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT,
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
         .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
         .build()
     ).toThrow("Invariant failed: nonce not set");
@@ -336,8 +336,8 @@ describe("V2DutchOrderBuilder", () => {
         .swapper(constants.AddressZero)
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -345,7 +345,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT,
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(99).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(99).div(100))
         .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
         .build()
     ).toThrow(
@@ -366,8 +366,8 @@ describe("V2DutchOrderBuilder", () => {
         .swapper(constants.AddressZero)
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -375,7 +375,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT,
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
         .outputOverrides([OUTPUT_START_AMOUNT.mul(102).div(100)])
         .build()
     ).toThrow(
@@ -394,8 +394,8 @@ describe("V2DutchOrderBuilder", () => {
       .nonce(BigNumber.from(100))
       .input({
         token: INPUT_TOKEN,
-        startAmount: INTPUT_START_AMOUNT,
-        endAmount: INTPUT_START_AMOUNT,
+        startAmount: INPUT_START_AMOUNT,
+        endAmount: INPUT_START_AMOUNT,
       })
       .output({
         token: OUTPUT_TOKEN,
@@ -403,7 +403,7 @@ describe("V2DutchOrderBuilder", () => {
         endAmount: OUTPUT_START_AMOUNT.mul(90).div(100),
         recipient: constants.AddressZero,
       })
-      .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+      .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
       .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
       .build();
 
@@ -422,8 +422,8 @@ describe("V2DutchOrderBuilder", () => {
       .nonce(BigNumber.from(100))
       .input({
         token: INPUT_TOKEN,
-        startAmount: INTPUT_START_AMOUNT,
-        endAmount: INTPUT_START_AMOUNT,
+        startAmount: INPUT_START_AMOUNT,
+        endAmount: INPUT_START_AMOUNT,
       })
       .output({
         token: OUTPUT_TOKEN,
@@ -431,7 +431,7 @@ describe("V2DutchOrderBuilder", () => {
         endAmount: OUTPUT_START_AMOUNT.mul(90).div(100),
         recipient: constants.AddressZero,
       })
-      .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+      .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
       .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
       .build();
 
@@ -452,8 +452,8 @@ describe("V2DutchOrderBuilder", () => {
         .nonce(BigNumber.from(100))
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -461,7 +461,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT.add(100),
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
         .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
         .build()
     ).toThrow("startAmount must be greater than endAmount: 100");
@@ -480,8 +480,8 @@ describe("V2DutchOrderBuilder", () => {
         .nonce(BigNumber.from(100))
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -489,7 +489,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT,
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
         .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
         .build()
     ).toThrow("Invariant failed: Deadline must be in the future: 1234");
@@ -508,8 +508,8 @@ describe("V2DutchOrderBuilder", () => {
         .nonce(BigNumber.from(100))
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -517,7 +517,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT,
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
         .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
         .build()
     ).toThrow(
@@ -540,8 +540,8 @@ describe("V2DutchOrderBuilder", () => {
         .nonce(BigNumber.from(100))
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -549,7 +549,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT,
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
         .outputOverrides([OUTPUT_START_AMOUNT.mul(98).div(100)])
         .build()
     ).toThrow(
@@ -583,8 +583,8 @@ describe("V2DutchOrderBuilder", () => {
         .deadline(deadline)
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -607,8 +607,8 @@ describe("V2DutchOrderBuilder", () => {
         .decayStartTime(1)
         .input({
           token: INPUT_TOKEN,
-          startAmount: INTPUT_START_AMOUNT,
-          endAmount: INTPUT_START_AMOUNT,
+          startAmount: INPUT_START_AMOUNT,
+          endAmount: INPUT_START_AMOUNT,
         })
         .output({
           token: OUTPUT_TOKEN,
@@ -616,7 +616,7 @@ describe("V2DutchOrderBuilder", () => {
           endAmount: OUTPUT_START_AMOUNT.mul(90).div(100),
           recipient: constants.AddressZero,
         })
-        .inputOverride(INTPUT_START_AMOUNT.mul(102).div(100))
+        .inputOverride(INPUT_START_AMOUNT.mul(102).div(100))
         .buildPartial();
 
       expect(order.info.outputs.length).toEqual(1);

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,4 +1,4 @@
-import { REACTOR_ADDRESS_MAPPING } from "./constants"
+import { REACTOR_ADDRESS_MAPPING } from "./constants";
 
 describe("REACTOR_ADDRESS_MAPPING", () => {
   it("matches the existing reactor mapping snapshot", () => {
@@ -25,6 +25,6 @@ describe("REACTOR_ADDRESS_MAPPING", () => {
         "Relay": "0x0000000000000000000000000000000000000001",
       },
     }
-  `)
-  })
-})
+  `);
+  });
+});

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -1,6 +1,12 @@
 import { OrderType, REVERSE_REACTOR_MAPPING } from "../constants";
 import { MissingConfiguration } from "../errors";
-import { DutchOrder, Order, RelayOrder, UnsignedV2DutchOrder } from "../order";
+import {
+  CosignedV2DutchOrder,
+  DutchOrder,
+  Order,
+  RelayOrder,
+  UnsignedV2DutchOrder,
+} from "../order";
 
 import { stripHexPrefix } from ".";
 
@@ -61,8 +67,16 @@ export class UniswapXOrderParser extends OrderParser {
     switch (orderType) {
       case OrderType.Dutch:
         return DutchOrder.parse(order, chainId);
-      case OrderType.Dutch_V2:
-        return UnsignedV2DutchOrder.parse(order, chainId);
+      case OrderType.Dutch_V2: {
+        // cosigned and unsigned serialized versions are the same format
+        const cosignedOrder = CosignedV2DutchOrder.parse(order, chainId);
+        // if no cosignature, returned unsigned variant
+        if (cosignedOrder.info.cosignature === "0x") {
+          return UnsignedV2DutchOrder.parse(order, chainId);
+        }
+        // if cosignature exists then returned cosigned version
+        return cosignedOrder;
+      }
       default:
         throw new MissingConfiguration("orderType", orderType);
     }


### PR DESCRIPTION
allow it to parse both unsigned and cosigned variants of the v2 dutch
order depending on the existence of the cosigner field
