### PR TITLE
feat: add v2 exclusivity override

### DIFF
--- a/src/builder/V2DutchOrderBuilder.ts
+++ b/src/builder/V2DutchOrderBuilder.ts
@@ -66,6 +66,7 @@ export class V2DutchOrderBuilder extends OrderBuilder {
         decayStartTime: 0,
         decayEndTime: 0,
         exclusiveFiller: ethers.constants.AddressZero,
+        exclusivityOverrideBps: BigNumber.from(0),
         inputOverride: BigNumber.from(0),
         outputOverrides: [],
       },
@@ -165,11 +166,27 @@ export class V2DutchOrderBuilder extends OrderBuilder {
         decayStartTime: 0,
         decayEndTime: 0,
         exclusiveFiller: exclusiveFiller,
+        exclusivityOverrideBps: BigNumber.from(0),
         inputOverride: BigNumber.from(0),
         outputOverrides: [],
       };
     }
     this.info.cosignerData.exclusiveFiller = exclusiveFiller;
+    return this;
+  }
+
+  exclusivityOverrideBps(exclusivityOverrideBps: BigNumber): this {
+    if (!this.info.cosignerData) {
+      this.info.cosignerData = {
+        decayStartTime: 0,
+        decayEndTime: 0,
+        exclusiveFiller: ethers.constants.AddressZero,
+        exclusivityOverrideBps: exclusivityOverrideBps,
+        inputOverride: BigNumber.from(0),
+        outputOverrides: [],
+      };
+    }
+    this.info.cosignerData.exclusivityOverrideBps = exclusivityOverrideBps;
     return this;
   }
 
@@ -205,6 +222,7 @@ export class V2DutchOrderBuilder extends OrderBuilder {
     this.decayStartTime(cosignerData.decayStartTime);
     this.decayEndTime(cosignerData.decayEndTime);
     this.exclusiveFiller(cosignerData.exclusiveFiller);
+    this.exclusivityOverrideBps(cosignerData.exclusivityOverrideBps);
     this.inputOverride(cosignerData.inputOverride);
     this.outputOverrides(cosignerData.outputOverrides);
     return this;
@@ -265,6 +283,10 @@ export class V2DutchOrderBuilder extends OrderBuilder {
       "exclusiveFiller not set"
     );
     invariant(
+      this.info.cosignerData.exclusivityOverrideBps !== undefined,
+      "exclusivityOverrideBps not set"
+    );
+    invariant(
       this.info.cosignerData.inputOverride !== undefined &&
         this.info.cosignerData.inputOverride.gte(this.info.input.startAmount),
       "inputOverride not set or smaller than original input"
@@ -309,6 +331,7 @@ export class V2DutchOrderBuilder extends OrderBuilder {
       decayStartTime: 0,
       decayEndTime: 0,
       exclusiveFiller: ethers.constants.AddressZero,
+      exclusivityOverrideBps: BigNumber.from(0),
       inputOverride: BigNumber.from(0),
       outputOverrides: [],
       ...overrides,

--- a/src/order/V2DutchOrder.test.ts
+++ b/src/order/V2DutchOrder.test.ts
@@ -15,6 +15,7 @@ const COSIGNER_DATA = {
   decayStartTime: NOW,
   decayEndTime: NOW + 1000,
   exclusiveFiller: ethers.constants.AddressZero,
+  exclusivityOverrideBps: BigNumber.from(0),
   inputOverride: RAW_AMOUNT,
   outputOverrides: [RAW_AMOUNT.mul(102).div(100)],
 };
@@ -174,6 +175,7 @@ describe("V2DutchOrder", () => {
             decayStartTime: Math.floor(new Date().getTime() / 1000),
             decayEndTime: Math.floor(new Date().getTime() / 1000) + 1000,
             exclusiveFiller: ethers.constants.AddressZero,
+            exclusivityOverrideBps: BigNumber.from(0),
             inputOverride: BigNumber.from(0),
             outputOverrides: [BigNumber.from(0)],
           },
@@ -248,6 +250,7 @@ describe("V2DutchOrder", () => {
         getFullOrderInfo({
           cosignerData: {
             exclusiveFiller: exclusiveFiller,
+            exclusivityOverrideBps: BigNumber.from(0),
             decayStartTime: Math.floor(new Date().getTime() / 1000),
             decayEndTime: Math.floor(new Date().getTime() / 1000) + 1000,
             inputOverride: RAW_AMOUNT,
@@ -279,6 +282,7 @@ describe("V2DutchOrder", () => {
         getFullOrderInfo({
           cosignerData: {
             exclusiveFiller,
+            exclusivityOverrideBps: BigNumber.from(0),
             decayStartTime: Math.floor(new Date().getTime() / 1000),
             decayEndTime: Math.floor(new Date().getTime() / 1000) + 1000,
             inputOverride: RAW_AMOUNT,
@@ -311,6 +315,7 @@ describe("V2DutchOrder", () => {
         getFullOrderInfo({
           cosignerData: {
             exclusiveFiller,
+            exclusivityOverrideBps: BigNumber.from(0),
             decayStartTime: Math.floor(new Date().getTime() / 1000),
             decayEndTime: Math.floor(new Date().getTime() / 1000) + 1000,
             inputOverride: RAW_AMOUNT,
@@ -341,6 +346,7 @@ describe("V2DutchOrder", () => {
         getFullOrderInfo({
           cosignerData: {
             exclusiveFiller,
+            exclusivityOverrideBps: BigNumber.from(0),
             decayStartTime: Math.floor(new Date().getTime() / 1000),
             decayEndTime: Math.floor(new Date().getTime() / 1000) + 1000,
             inputOverride: RAW_AMOUNT,


### PR DESCRIPTION
previously was missing this field that exists in the contracts so
internal abi decoding was not working properlyu
