### PR TITLE
fix: rename to baseInput/outputs for X v2

### DIFF
--- a/src/builder/V2DutchOrderBuilder.test.ts
+++ b/src/builder/V2DutchOrderBuilder.test.ts
@@ -44,7 +44,7 @@ describe("V2DutchOrderBuilder", () => {
       .build();
 
     expect(order.info.cosignerData.decayStartTime).toEqual(deadline - 100);
-    expect(order.info.outputs.length).toEqual(1);
+    expect(order.info.baseOutputs.length).toEqual(1);
   });
 
   it("Builds a valid order with validation", () => {
@@ -84,7 +84,7 @@ describe("V2DutchOrderBuilder", () => {
       .build();
 
     expect(order.info.cosignerData.decayStartTime).toEqual(deadline - 100);
-    expect(order.info.outputs.length).toEqual(1);
+    expect(order.info.baseOutputs.length).toEqual(1);
     expect(order.validation).toEqual({
       type: ValidationType.ExclusiveFiller,
       data: {
@@ -213,7 +213,7 @@ describe("V2DutchOrderBuilder", () => {
       .build();
 
     expect(order.info.cosignerData.decayStartTime).toEqual(deadline - 100);
-    expect(order.info.outputs.length).toEqual(2);
+    expect(order.info.baseOutputs.length).toEqual(2);
   });
 
   it("cosigner not set", () => {
@@ -408,7 +408,7 @@ describe("V2DutchOrderBuilder", () => {
       .build();
 
     expect(order.info.cosignerData.decayEndTime).toEqual(deadline);
-    expect(order.info.outputs.length).toEqual(1);
+    expect(order.info.baseOutputs.length).toEqual(1);
   });
 
   it("deadline defaults to decayEndTime", () => {
@@ -436,7 +436,7 @@ describe("V2DutchOrderBuilder", () => {
       .build();
 
     expect(order.info.deadline).toEqual(decayEndTime);
-    expect(order.info.outputs.length).toEqual(1);
+    expect(order.info.baseOutputs.length).toEqual(1);
   });
 
   it("startAmount <= endAmount", () => {
@@ -594,7 +594,7 @@ describe("V2DutchOrderBuilder", () => {
         })
         .buildPartial();
 
-      expect(order.info.outputs.length).toEqual(1);
+      expect(order.info.baseOutputs.length).toEqual(1);
     });
 
     it("builds an unsigned partial order with incomplete cosignerData values", () => {
@@ -619,7 +619,7 @@ describe("V2DutchOrderBuilder", () => {
         .inputOverride(INPUT_START_AMOUNT.mul(98).div(100))
         .buildPartial();
 
-      expect(order.info.outputs.length).toEqual(1);
+      expect(order.info.baseOutputs.length).toEqual(1);
     });
   });
 });

--- a/src/order/V2DutchOrder.test.ts
+++ b/src/order/V2DutchOrder.test.ts
@@ -34,12 +34,12 @@ describe("V2DutchOrder", () => {
         additionalValidationData: "0x",
         cosigner: ethers.constants.AddressZero,
         cosignerData: COSIGNER_DATA,
-        input: {
+        baseInput: {
           token: INPUT_TOKEN,
           startAmount: RAW_AMOUNT,
           endAmount: RAW_AMOUNT,
         },
-        outputs: [
+        baseOutputs: [
           {
             token: OUTPUT_TOKEN,
             startAmount: RAW_AMOUNT,
@@ -66,12 +66,12 @@ describe("V2DutchOrder", () => {
         additionalValidationData: "0x",
         cosigner: ethers.constants.AddressZero,
         cosignerData: undefined,
-        input: {
+        baseInput: {
           token: INPUT_TOKEN,
           startAmount: RAW_AMOUNT,
           endAmount: RAW_AMOUNT,
         },
-        outputs: [
+        baseOutputs: [
           {
             token: OUTPUT_TOKEN,
             startAmount: RAW_AMOUNT,
@@ -97,12 +97,12 @@ describe("V2DutchOrder", () => {
     const orderInfoJSON = {
       ...getOrderInfo({}),
       nonce: "10",
-      input: {
+      baseInput: {
         token: INPUT_TOKEN,
         startAmount: "1000000",
         endAmount: "1000000",
       },
-      outputs: [
+      baseOutputs: [
         {
           token: OUTPUT_TOKEN,
           startAmount: "1000000",
@@ -113,8 +113,8 @@ describe("V2DutchOrder", () => {
       cosignerData: undefined,
     };
     const order = UnsignedV2DutchOrder.fromJSON(orderInfoJSON, 1);
-    expect(order.info.input.startAmount).toEqual(BigNumber.from("1000000"));
-    expect(order.info.outputs[0].startAmount).toEqual(
+    expect(order.info.baseInput.startAmount).toEqual(BigNumber.from("1000000"));
+    expect(order.info.baseOutputs[0].startAmount).toEqual(
       BigNumber.from("1000000")
     );
   });
@@ -158,11 +158,11 @@ describe("V2DutchOrder", () => {
       const resolved = order.resolve({
         timestamp: order.info.cosignerData.decayStartTime - 100,
       });
-      expect(resolved.input.token).toEqual(order.info.input.token);
+      expect(resolved.input.token).toEqual(order.info.baseInput.token);
       expect(resolved.input.amount).toEqual(
         order.info.cosignerData.inputOverride
       );
-      expect(resolved.outputs[0].token).toEqual(order.info.outputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
       expect(resolved.outputs[0].amount).toEqual(
         order.info.cosignerData.outputOverrides[0]
       );
@@ -185,11 +185,11 @@ describe("V2DutchOrder", () => {
       const resolved = order.resolve({
         timestamp: order.info.cosignerData!.decayStartTime - 100,
       });
-      expect(resolved.input.token).toEqual(order.info.input.token);
-      expect(resolved.input.amount).toEqual(order.info.input.startAmount);
-      expect(resolved.outputs[0].token).toEqual(order.info.outputs[0].token);
+      expect(resolved.input.token).toEqual(order.info.baseInput.token);
+      expect(resolved.input.amount).toEqual(order.info.baseInput.startAmount);
+      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
       expect(resolved.outputs[0].amount).toEqual(
-        order.info.outputs[0].startAmount
+        order.info.baseOutputs[0].startAmount
       );
     });
 
@@ -198,13 +198,13 @@ describe("V2DutchOrder", () => {
       const resolved = order.resolve({
         timestamp: order.info.cosignerData.decayStartTime,
       });
-      expect(resolved.input.token).toEqual(order.info.input.token);
+      expect(resolved.input.token).toEqual(order.info.baseInput.token);
       expect(resolved.input.amount).toEqual(
         order.info.cosignerData.inputOverride
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.outputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
       expect(resolved.outputs[0].amount).toEqual(
         order.info.cosignerData.outputOverrides[0]
       );
@@ -215,15 +215,15 @@ describe("V2DutchOrder", () => {
       const resolved = order.resolve({
         timestamp: order.info.cosignerData.decayEndTime,
       });
-      expect(resolved.input.token).toEqual(order.info.input.token);
+      expect(resolved.input.token).toEqual(order.info.baseInput.token);
       expect(resolved.input.amount).toEqual(
         order.info.cosignerData.inputOverride
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.outputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
       expect(resolved.outputs[0].amount).toEqual(
-        order.info.outputs[0].endAmount
+        order.info.baseOutputs[0].endAmount
       );
     });
 
@@ -232,15 +232,15 @@ describe("V2DutchOrder", () => {
       const resolved = order.resolve({
         timestamp: order.info.cosignerData.decayEndTime + 100,
       });
-      expect(resolved.input.token).toEqual(order.info.input.token);
+      expect(resolved.input.token).toEqual(order.info.baseInput.token);
       expect(resolved.input.amount).toEqual(
         order.info.cosignerData.inputOverride
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.outputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
       expect(resolved.outputs[0].amount).toEqual(
-        order.info.outputs[0].endAmount
+        order.info.baseOutputs[0].endAmount
       );
     });
 
@@ -263,13 +263,13 @@ describe("V2DutchOrder", () => {
         timestamp: order.info.cosignerData.decayStartTime - 1,
         filler: exclusiveFiller,
       });
-      expect(resolved.input.token).toEqual(order.info.input.token);
+      expect(resolved.input.token).toEqual(order.info.baseInput.token);
       expect(resolved.input.amount).toEqual(
         order.info.cosignerData.inputOverride
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.outputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
       expect(resolved.outputs[0].amount).toEqual(
         order.info.cosignerData.outputOverrides[0]
       );
@@ -296,13 +296,13 @@ describe("V2DutchOrder", () => {
         timestamp: order.info.cosignerData.decayStartTime - 1,
         filler: nonExclusiveFiller,
       });
-      expect(resolved.input.token).toEqual(order.info.input.token);
+      expect(resolved.input.token).toEqual(order.info.baseInput.token);
       expect(resolved.input.amount).toEqual(
         order.info.cosignerData.inputOverride
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.outputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
       expect(resolved.outputs[0].amount).toEqual(
         order.info.cosignerData.outputOverrides[0]
       );
@@ -328,15 +328,15 @@ describe("V2DutchOrder", () => {
         timestamp: order.info.cosignerData.decayEndTime,
         filler: nonExclusiveFiller,
       });
-      expect(resolved.input.token).toEqual(order.info.input.token);
+      expect(resolved.input.token).toEqual(order.info.baseInput.token);
       expect(resolved.input.amount).toEqual(
         order.info.cosignerData.inputOverride
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.outputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
       expect(resolved.outputs[0].amount).toEqual(
-        order.info.outputs[0].endAmount
+        order.info.baseOutputs[0].endAmount
       );
     });
 
@@ -358,13 +358,13 @@ describe("V2DutchOrder", () => {
       const resolved = order.resolve({
         timestamp: order.info.cosignerData.decayStartTime - 1,
       });
-      expect(resolved.input.token).toEqual(order.info.input.token);
+      expect(resolved.input.token).toEqual(order.info.baseInput.token);
       expect(resolved.input.amount).toEqual(
         order.info.cosignerData.inputOverride
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.outputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
       expect(resolved.outputs[0].amount).toEqual(
         order.info.cosignerData.outputOverrides[0]
       );

--- a/src/order/V2DutchOrder.ts
+++ b/src/order/V2DutchOrder.ts
@@ -42,8 +42,8 @@ export type CosignerDataJSON = {
 
 export type UnsignedV2DutchOrderInfo = OrderInfo & {
   cosigner: string;
-  input: DutchInput;
-  outputs: DutchOutput[];
+  baseInput: DutchInput;
+  baseOutputs: DutchOutput[];
 };
 
 export type CosignedV2DutchOrderInfo = UnsignedV2DutchOrderInfo & {
@@ -53,11 +53,11 @@ export type CosignedV2DutchOrderInfo = UnsignedV2DutchOrderInfo & {
 
 export type UnsignedV2DutchOrderInfoJSON = Omit<
   UnsignedV2DutchOrderInfo,
-  "nonce" | "input" | "outputs" | "cosignerData"
+  "nonce" | "baseInput" | "baseOutputs" | "cosignerData"
 > & {
   nonce: string;
-  input: DutchInputJSON;
-  outputs: DutchOutputJSON[];
+  baseInput: DutchInputJSON;
+  baseOutputs: DutchOutputJSON[];
 };
 
 export type CosignedV2DutchOrderInfoJSON = UnsignedV2DutchOrderInfoJSON & {
@@ -135,12 +135,12 @@ export class UnsignedV2DutchOrder implements OffChainOrder {
       {
         ...json,
         nonce: BigNumber.from(json.nonce),
-        input: {
-          token: json.input.token,
-          startAmount: BigNumber.from(json.input.startAmount),
-          endAmount: BigNumber.from(json.input.endAmount),
+        baseInput: {
+          token: json.baseInput.token,
+          startAmount: BigNumber.from(json.baseInput.startAmount),
+          endAmount: BigNumber.from(json.baseInput.endAmount),
         },
-        outputs: json.outputs.map((output) => ({
+        baseOutputs: json.baseOutputs.map((output) => ({
           token: output.token,
           startAmount: BigNumber.from(output.startAmount),
           endAmount: BigNumber.from(output.endAmount),
@@ -180,12 +180,12 @@ export class UnsignedV2DutchOrder implements OffChainOrder {
       deadline: this.info.deadline,
       additionalValidationContract: this.info.additionalValidationContract,
       additionalValidationData: this.info.additionalValidationData,
-      input: {
-        token: this.info.input.token,
-        startAmount: this.info.input.startAmount.toString(),
-        endAmount: this.info.input.endAmount.toString(),
+      baseInput: {
+        token: this.info.baseInput.token,
+        startAmount: this.info.baseInput.startAmount.toString(),
+        endAmount: this.info.baseInput.endAmount.toString(),
       },
-      outputs: this.info.outputs.map((output) => ({
+      baseOutputs: this.info.baseOutputs.map((output) => ({
         token: output.token,
         startAmount: output.startAmount.toString(),
         endAmount: output.endAmount.toString(),
@@ -212,11 +212,11 @@ export class UnsignedV2DutchOrder implements OffChainOrder {
         ],
         this.info.cosigner,
         [
-          this.info.input.token,
-          this.info.input.startAmount,
-          this.info.input.endAmount,
+          this.info.baseInput.token,
+          this.info.baseInput.startAmount,
+          this.info.baseInput.endAmount,
         ],
-        this.info.outputs.map((output) => [
+        this.info.baseOutputs.map((output) => [
           output.token,
           output.startAmount,
           output.endAmount,
@@ -287,8 +287,8 @@ export class UnsignedV2DutchOrder implements OffChainOrder {
   private toPermit(): PermitTransferFrom {
     return {
       permitted: {
-        token: this.info.input.token,
-        amount: this.info.input.endAmount,
+        token: this.info.baseInput.token,
+        amount: this.info.baseInput.endAmount,
       },
       spender: this.info.reactor,
       nonce: this.info.nonce,
@@ -307,10 +307,10 @@ export class UnsignedV2DutchOrder implements OffChainOrder {
         additionalValidationData: this.info.additionalValidationData,
       },
       cosigner: this.info.cosigner,
-      baseInputToken: this.info.input.token,
-      baseInputStartAmount: this.info.input.startAmount,
-      baseInputEndAmount: this.info.input.endAmount,
-      baseOutputs: this.info.outputs,
+      baseInputToken: this.info.baseInput.token,
+      baseInputStartAmount: this.info.baseInput.startAmount,
+      baseInputEndAmount: this.info.baseInput.endAmount,
+      baseOutputs: this.info.baseOutputs,
     };
   }
 
@@ -378,12 +378,12 @@ export class CosignedV2DutchOrder extends UnsignedV2DutchOrder {
       {
         ...json,
         nonce: BigNumber.from(json.nonce),
-        input: {
-          token: json.input.token,
-          startAmount: BigNumber.from(json.input.startAmount),
-          endAmount: BigNumber.from(json.input.endAmount),
+        baseInput: {
+          token: json.baseInput.token,
+          startAmount: BigNumber.from(json.baseInput.startAmount),
+          endAmount: BigNumber.from(json.baseInput.endAmount),
         },
-        outputs: json.outputs.map((output) => ({
+        baseOutputs: json.baseOutputs.map((output) => ({
           token: output.token,
           startAmount: BigNumber.from(output.startAmount),
           endAmount: BigNumber.from(output.endAmount),
@@ -459,21 +459,21 @@ export class CosignedV2DutchOrder extends UnsignedV2DutchOrder {
   resolve(options: OrderResolutionOptions): ResolvedUniswapXOrder {
     return {
       input: {
-        token: this.info.input.token,
+        token: this.info.baseInput.token,
         amount: getDecayedAmount(
           {
             decayStartTime: this.info.cosignerData.decayStartTime,
             decayEndTime: this.info.cosignerData.decayEndTime,
             startAmount: originalIfZero(
               this.info.cosignerData.inputOverride,
-              this.info.input.startAmount
+              this.info.baseInput.startAmount
             ),
-            endAmount: this.info.input.endAmount,
+            endAmount: this.info.baseInput.endAmount,
           },
           options.timestamp
         ),
       },
-      outputs: this.info.outputs.map((output, idx) => {
+      outputs: this.info.baseOutputs.map((output, idx) => {
         return {
           token: output.token,
           amount: getDecayedAmount(
@@ -510,11 +510,11 @@ export class CosignedV2DutchOrder extends UnsignedV2DutchOrder {
         ],
         this.info.cosigner,
         [
-          this.info.input.token,
-          this.info.input.startAmount,
-          this.info.input.endAmount,
+          this.info.baseInput.token,
+          this.info.baseInput.startAmount,
+          this.info.baseInput.endAmount,
         ],
-        this.info.outputs.map((output) => [
+        this.info.baseOutputs.map((output) => [
           output.token,
           output.startAmount,
           output.endAmount,
@@ -584,12 +584,12 @@ function parseSerializedOrder(serialized: string): CosignedV2DutchOrderInfo {
     additionalValidationContract,
     additionalValidationData,
     cosigner,
-    input: {
+    baseInput: {
       token: inputToken,
       startAmount: inputStartAmount,
       endAmount: inputEndAmount,
     },
-    outputs: outputs.map(
+    baseOutputs: outputs.map(
       ([token, startAmount, endAmount, recipient]: [
         string,
         number,

--- a/src/trade/V2DutchOrderTrade.test.ts
+++ b/src/trade/V2DutchOrderTrade.test.ts
@@ -32,12 +32,12 @@ describe("V2DutchOrderTrade", () => {
     cosigner: "0x0000000000000000000000000000000000000000",
     additionalValidationContract: ethers.constants.AddressZero,
     additionalValidationData: "0x",
-    input: {
+    baseInput: {
       token: USDC.address,
       startAmount: BigNumber.from(1000),
       endAmount: BigNumber.from(1000),
     },
-    outputs: [
+    baseOutputs: [
       {
         token: DAI.address,
         startAmount: NON_FEE_OUTPUT_AMOUNT,
@@ -62,7 +62,7 @@ describe("V2DutchOrderTrade", () => {
 
   it("returns the right input amount for an exact-in trade", () => {
     expect(trade.inputAmount.quotient.toString()).toEqual(
-      orderInfo.input.startAmount.toString()
+      orderInfo.baseInput.startAmount.toString()
     );
   });
 

--- a/src/trade/V2DutchOrderTrade.ts
+++ b/src/trade/V2DutchOrderTrade.ts
@@ -42,7 +42,7 @@ export class V2DutchOrderTrade<
 
     const amount = CurrencyAmount.fromRawAmount(
       this._currencyIn,
-      this.order.info.input.startAmount.toString()
+      this.order.info.baseInput.startAmount.toString()
     );
     this._inputAmount = amount;
     return amount;
@@ -51,7 +51,7 @@ export class V2DutchOrderTrade<
   public get outputAmounts(): CurrencyAmount<TOutput>[] {
     if (this._outputAmounts) return this._outputAmounts;
 
-    const amounts = this.order.info.outputs.map((output) => {
+    const amounts = this.order.info.baseOutputs.map((output) => {
       // assume single chain ids across all outputs for now
       const currencyOut = this._currenciesOut.find((currency) =>
         areCurrenciesEqual(currency, output.token, currency.chainId)
@@ -85,10 +85,10 @@ export class V2DutchOrderTrade<
     if (this._firstNonFeeOutputStartEndAmounts)
       return this._firstNonFeeOutputStartEndAmounts;
 
-    if (this.order.info.outputs.length === 0) {
+    if (this.order.info.baseOutputs.length === 0) {
       throw new Error("there must be at least one output token");
     }
-    const output = this.order.info.outputs[0];
+    const output = this.order.info.baseOutputs[0];
 
     // assume single chain ids across all outputs for now
     const currencyOut = this._currenciesOut.find((currency) =>
@@ -128,7 +128,7 @@ export class V2DutchOrderTrade<
   public maximumAmountIn(): CurrencyAmount<TInput> {
     return CurrencyAmount.fromRawAmount(
       this._currencyIn,
-      this.order.info.input.endAmount.toString()
+      this.order.info.baseInput.endAmount.toString()
     );
   }
 


### PR DESCRIPTION
v2 /quote is returning `baseInput` and `baseOutputs`, which doesn't match with UnsignedV2DutchOrderInfo type. Should be called baseInput & baseOutputs. 