### PR TITLE
fix: Add UniswapX and Relay event watchers

### DIFF
--- a/integration/test/EventWatcher.ts
+++ b/integration/test/EventWatcher.ts
@@ -1,22 +1,25 @@
 import hre, { ethers } from "hardhat";
 import { expect } from "chai";
-import { BigNumber, Signer, Event } from "ethers";
+import { BigNumber, Signer } from "ethers";
 
 import { BlockchainTime } from "./utils/time";
 
 import ExclusiveDutchOrderReactorAbi from "../../abis/ExclusiveDutchOrderReactor.json";
+import RelayOrderReactorAbi from "../../abis/RelayOrderReactor.json";
 import Permit2Abi from "../../abis/Permit2.json";
 import MockERC20Abi from "../../abis/MockERC20.json";
 
 import {
   Permit2,
-  DutchOrderReactor,
+  ExclusiveDutchOrderReactor,
   MockERC20,
+  RelayOrderReactor,
 } from "../../src/contracts";
-import { DutchOrderBuilder, EventWatcher, FillData } from "../../";
+import { DutchOrderBuilder, UniswapXEventWatcher, FillData, RelayEventWatcher, RelayOrderBuilder } from "../../";
+import { deployAndReturnPermit2 } from "./utils/permit2";
 
-describe("EventWatcher", () => {
-  let reactor: DutchOrderReactor;
+describe("UniswapXEventWatcher", () => {
+  let reactor: ExclusiveDutchOrderReactor;
   let permit2: Permit2;
   let chainId: number;
   let swapper: ethers.Wallet;
@@ -24,7 +27,7 @@ describe("EventWatcher", () => {
   let tokenOut: MockERC20;
   let admin: Signer;
   let filler: Signer;
-  let watcher: EventWatcher;
+  let watcher: UniswapXEventWatcher;
 
   const DIRECT_FILL = '0x0000000000000000000000000000000000000001';
 
@@ -43,7 +46,7 @@ describe("EventWatcher", () => {
     reactor = (await reactorFactory.deploy(
       permit2.address,
       ethers.constants.AddressZero
-    )) as DutchOrderReactor;
+    )) as ExclusiveDutchOrderReactor;
 
     chainId = hre.network.config.chainId || 1;
 
@@ -76,7 +79,7 @@ describe("EventWatcher", () => {
     await tokenOut
       .connect(filler)
       .approve(reactor.address, ethers.constants.MaxUint256);
-    watcher = new EventWatcher(ethers.provider, reactor.address);
+    watcher = new UniswapXEventWatcher(ethers.provider, reactor.address);
   });
 
   it("Fetches fill events", async () => {
@@ -172,6 +175,163 @@ describe("EventWatcher", () => {
     const res = await reactor
       .connect(filler)
       .execute(
+        { order: order.serialize(), sig: signature },
+      );
+    await res.wait();
+  });
+});
+
+describe("RelayEventWatcher", () => {
+  let reactor: RelayOrderReactor;
+  let permit2: Permit2;
+  let chainId: number;
+  let swapper: ethers.Wallet;
+  let tokenIn: MockERC20;
+  let admin: Signer;
+  let filler: Signer;
+  let inputRecipient: string;
+  let feeRecipient: string;
+  let watcher: RelayEventWatcher;
+
+  before(async () => {
+    [admin, filler] = await ethers.getSigners();
+
+    inputRecipient = await ethers.Wallet.createRandom().connect(ethers.provider).getAddress();
+    feeRecipient = await ethers.Wallet.createRandom().connect(ethers.provider).getAddress();
+    
+    permit2 = await deployAndReturnPermit2(admin);
+
+    const reactorFactory = await ethers.getContractFactory(
+      RelayOrderReactorAbi.abi,
+      RelayOrderReactorAbi.bytecode
+    );
+    reactor = (await reactorFactory.deploy(
+      ethers.constants.AddressZero
+    )) as RelayOrderReactor;
+
+    chainId = hre.network.config.chainId || 1;
+
+    swapper = ethers.Wallet.createRandom().connect(ethers.provider);
+    await admin.sendTransaction({
+      to: await swapper.getAddress(),
+      value: BigNumber.from(10).pow(18),
+    });
+
+    const tokenFactory = await ethers.getContractFactory(
+      MockERC20Abi.abi,
+      MockERC20Abi.bytecode
+    );
+    tokenIn = (await tokenFactory.deploy("TEST A", "ta", 18)) as MockERC20;
+
+    await tokenIn.mint(
+      await swapper.getAddress(),
+      BigNumber.from(10).pow(18).mul(100)
+    );
+    await tokenIn
+      .connect(swapper)
+      .approve(permit2.address, ethers.constants.MaxUint256);
+
+    watcher = new RelayEventWatcher(ethers.provider, reactor.address);
+  });
+
+  it("Fetches fill events", async () => {
+    const amount = BigNumber.from(10).pow(18);
+    const deadline = await new BlockchainTime().secondsFromNow(1000);
+    const swapperAddress = await swapper.getAddress();
+    const preBuildOrder = new RelayOrderBuilder(
+      chainId,
+      reactor.address,
+      permit2.address
+    )
+      .deadline(deadline)
+      .swapper(swapperAddress)
+      .nonce(BigNumber.from(98))
+      .input({
+        token: tokenIn.address,
+        amount: amount,
+        recipient: inputRecipient,
+      })
+      .fee({
+        token: tokenIn.address,
+        startAmount: BigNumber.from(10).pow(17).mul(9),
+        endAmount: amount,
+        startTime: deadline - 100,
+        endTime: deadline,
+      })
+      .universalRouterCalldata('0x');
+
+    let order = preBuildOrder.build();
+
+    const { domain, types, values } = order.permitData();
+    const signature = await swapper._signTypedData(domain, types, values);
+
+    const res = await reactor
+      .connect(filler)
+      ["execute((bytes,bytes))"](
+        { order: order.serialize(), sig: signature },
+      );
+    await res.wait();
+
+    const bn = await ethers.provider.getBlockNumber();
+
+    const logs = await watcher.getFillEvents(0, bn);
+    expect(logs.length).to.equal(1);
+    expect(logs[0].orderHash).to.equal(order.hash());
+    expect(logs[0].filler).to.equal(await filler.getAddress());
+    expect(logs[0].swapper).to.equal(await swapper.getAddress());
+    expect(logs[0].nonce.toString()).to.equal("98");
+
+    const fillInfo = await watcher.getFillInfo(0, bn);
+    expect(fillInfo.length).to.equal(1);
+    expect(fillInfo[0].blockNumber).to.greaterThan(0);
+    // no outputs in this test because no universal router set in test reactor
+    expect(fillInfo[0].inputs.length).to.equal(1);
+    expect(fillInfo[0].inputs[0].token).to.equal(tokenIn.address);
+    // expect swapper paid the fee to the filler
+    expect(fillInfo[0].inputs[0].amount.toString()).to.equal(
+      BigNumber.from(10).pow(17).mul(9).toString()
+    );
+  });
+
+  it("Handles callbacks on fill events", async () => {
+    const amount = BigNumber.from(10).pow(18);
+    const deadline = await new BlockchainTime().secondsFromNow(1000);
+    const swapperAddress = await swapper.getAddress();
+    const preBuildOrder = new RelayOrderBuilder(
+      chainId,
+      reactor.address,
+      permit2.address
+    )
+      .deadline(deadline)
+      .swapper(swapperAddress)
+      .nonce(BigNumber.from(99))
+      .input({
+        token: tokenIn.address,
+        amount: amount,
+        recipient: inputRecipient,
+      })
+      .fee({
+        token: tokenIn.address,
+        startAmount: BigNumber.from(10).pow(17).mul(9),
+        endAmount: amount,
+        startTime: deadline - 100,
+        endTime: deadline,
+      })
+      .universalRouterCalldata('0x');
+
+    let order = preBuildOrder.build();
+
+    const { domain, types, values } = order.permitData();
+    const signature = await swapper._signTypedData(domain, types, values);
+
+    const fillerAddress = await filler.getAddress();
+    watcher.onFill((fill: FillData) => {
+      expect(fill.filler).to.equal(fillerAddress);
+      expect(fill.swapper).to.equal(swapperAddress);
+    });
+    const res = await reactor
+      .connect(filler)
+      ["execute((bytes,bytes))"](
         { order: order.serialize(), sig: signature },
       );
     await res.wait();

--- a/integration/test/V2DutchOrder.spec.ts
+++ b/integration/test/V2DutchOrder.spec.ts
@@ -130,11 +130,11 @@ describe("DutchV2Order", () => {
       expect(order.info.cosigner).to.eq(cosignerAddress);
       expect(order.info.nonce.toNumber()).to.eq(100);
 
-      expect(order.info.input.token).to.eq(tokenIn.address);
-      expect(order.info.input.startAmount).to.eq(AMOUNT);
-      expect(order.info.input.endAmount).to.eq(AMOUNT);
+      expect(order.info.baseInput.token).to.eq(tokenIn.address);
+      expect(order.info.baseInput.startAmount).to.eq(AMOUNT);
+      expect(order.info.baseInput.endAmount).to.eq(AMOUNT);
 
-      const builtOutput = order.info.outputs[0];
+      const builtOutput = order.info.baseOutputs[0];
 
       expect(builtOutput.token).to.eq(tokenOut.address);
       expect(builtOutput.startAmount).to.eq(AMOUNT);
@@ -145,7 +145,7 @@ describe("DutchV2Order", () => {
       order = preBuildOrder
         .nonFeeRecipient(ethers.constants.AddressZero, FEE_RECIPIENT)
         .buildPartial();
-      expect(order.info.outputs[0].recipient).to.eq(
+      expect(order.info.baseOutputs[0].recipient).to.eq(
         ethers.constants.AddressZero
       );
     });
@@ -183,17 +183,17 @@ describe("DutchV2Order", () => {
         });
 
       let order = preBuildOrder.buildPartial();
-      expect(order.info.outputs[0].recipient).to.eq(swapperAddress);
-      expect(order.info.outputs[1].recipient).to.eq(FEE_RECIPIENT);
+      expect(order.info.baseOutputs[0].recipient).to.eq(swapperAddress);
+      expect(order.info.baseOutputs[1].recipient).to.eq(FEE_RECIPIENT);
 
       order = preBuildOrder
         .nonFeeRecipient(ethers.constants.AddressZero, FEE_RECIPIENT)
         .buildPartial();
 
-      expect(order.info.outputs[0].recipient).to.eq(
+      expect(order.info.baseOutputs[0].recipient).to.eq(
         ethers.constants.AddressZero
       );
-      expect(order.info.outputs[1].recipient).to.eq(FEE_RECIPIENT);
+      expect(order.info.baseOutputs[1].recipient).to.eq(FEE_RECIPIENT);
     });
 
     it("nonFeeRecipient updates recipient for all outputs if no feeRecipient given", async () => {
@@ -229,17 +229,17 @@ describe("DutchV2Order", () => {
         });
 
       let order = preBuildOrder.buildPartial();
-      expect(order.info.outputs[0].recipient).to.eq(swapperAddress);
-      expect(order.info.outputs[1].recipient).to.eq(FEE_RECIPIENT);
+      expect(order.info.baseOutputs[0].recipient).to.eq(swapperAddress);
+      expect(order.info.baseOutputs[1].recipient).to.eq(FEE_RECIPIENT);
 
       order = preBuildOrder
         .nonFeeRecipient(ethers.constants.AddressZero)
         .buildPartial();
 
-      expect(order.info.outputs[0].recipient).to.eq(
+      expect(order.info.baseOutputs[0].recipient).to.eq(
         ethers.constants.AddressZero
       );
-      expect(order.info.outputs[1].recipient).to.eq(
+      expect(order.info.baseOutputs[1].recipient).to.eq(
         ethers.constants.AddressZero
       );
     });
@@ -277,8 +277,8 @@ describe("DutchV2Order", () => {
         });
 
       let order = preBuildOrder.buildPartial();
-      expect(order.info.outputs[0].recipient).to.eq(swapperAddress);
-      expect(order.info.outputs[1].recipient).to.eq(FEE_RECIPIENT);
+      expect(order.info.baseOutputs[0].recipient).to.eq(swapperAddress);
+      expect(order.info.baseOutputs[1].recipient).to.eq(FEE_RECIPIENT);
 
       expect(() =>
         preBuildOrder
@@ -334,11 +334,11 @@ describe("DutchV2Order", () => {
       expect(order.info.cosignature).to.eq(cosignature);
       expect(order.info.nonce.toNumber()).to.eq(NONCE);
 
-      expect(order.info.input.token).to.eq(tokenIn.address);
-      expect(order.info.input.startAmount).to.eq(AMOUNT);
-      expect(order.info.input.endAmount).to.eq(AMOUNT);
+      expect(order.info.baseInput.token).to.eq(tokenIn.address);
+      expect(order.info.baseInput.startAmount).to.eq(AMOUNT);
+      expect(order.info.baseInput.endAmount).to.eq(AMOUNT);
 
-      const builtOutput = order.info.outputs[0];
+      const builtOutput = order.info.baseOutputs[0];
 
       expect(builtOutput.token).to.eq(tokenOut.address);
       expect(builtOutput.startAmount).to.eq(AMOUNT);
@@ -451,8 +451,8 @@ describe("DutchV2Order", () => {
         fillerTokenInBalanceBefore.add(AMOUNT).toString()
       );
 
-      const amountOut = order.info.outputs[0].startAmount
-        .add(order.info.outputs[0].endAmount)
+      const amountOut = order.info.baseOutputs[0].startAmount
+        .add(order.info.baseOutputs[0].endAmount)
         .div(2);
 
       // some variance in block timestamp so we need to use a threshold
@@ -754,8 +754,8 @@ describe("DutchV2Order", () => {
         openFillerTokenInBalanceBefore.add(AMOUNT).toString()
       );
 
-      const amountOut = order.info.outputs[0].startAmount
-        .add(order.info.outputs[0].endAmount)
+      const amountOut = order.info.baseOutputs[0].startAmount
+        .add(order.info.baseOutputs[0].endAmount)
         .div(2);
 
       // some variance in block timestamp so we need to use a threshold

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniswap/uniswapx-sdk",
   "author": "Uniswap",
-  "version": "2.0.1-alpha.8",
+  "version": "2.0.1-alpha.9",
   "license": "MIT",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/builder/V2DutchOrderBuilder.ts
+++ b/src/builder/V2DutchOrderBuilder.ts
@@ -288,7 +288,9 @@ export class V2DutchOrderBuilder extends OrderBuilder {
     );
     invariant(
       this.info.cosignerData.inputOverride !== undefined &&
-        this.info.cosignerData.inputOverride.lte(this.info.baseInput.startAmount),
+        this.info.cosignerData.inputOverride.lte(
+          this.info.baseInput.startAmount
+        ),
       "inputOverride not set or larger than original input"
     );
     invariant(

--- a/src/order/V2DutchOrder.test.ts
+++ b/src/order/V2DutchOrder.test.ts
@@ -162,7 +162,9 @@ describe("V2DutchOrder", () => {
       expect(resolved.input.amount).toEqual(
         order.info.cosignerData.inputOverride
       );
-      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(
+        order.info.baseOutputs[0].token
+      );
       expect(resolved.outputs[0].amount).toEqual(
         order.info.cosignerData.outputOverrides[0]
       );
@@ -187,7 +189,9 @@ describe("V2DutchOrder", () => {
       });
       expect(resolved.input.token).toEqual(order.info.baseInput.token);
       expect(resolved.input.amount).toEqual(order.info.baseInput.startAmount);
-      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(
+        order.info.baseOutputs[0].token
+      );
       expect(resolved.outputs[0].amount).toEqual(
         order.info.baseOutputs[0].startAmount
       );
@@ -204,7 +208,9 @@ describe("V2DutchOrder", () => {
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(
+        order.info.baseOutputs[0].token
+      );
       expect(resolved.outputs[0].amount).toEqual(
         order.info.cosignerData.outputOverrides[0]
       );
@@ -221,7 +227,9 @@ describe("V2DutchOrder", () => {
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(
+        order.info.baseOutputs[0].token
+      );
       expect(resolved.outputs[0].amount).toEqual(
         order.info.baseOutputs[0].endAmount
       );
@@ -238,7 +246,9 @@ describe("V2DutchOrder", () => {
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(
+        order.info.baseOutputs[0].token
+      );
       expect(resolved.outputs[0].amount).toEqual(
         order.info.baseOutputs[0].endAmount
       );
@@ -269,7 +279,9 @@ describe("V2DutchOrder", () => {
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(
+        order.info.baseOutputs[0].token
+      );
       expect(resolved.outputs[0].amount).toEqual(
         order.info.cosignerData.outputOverrides[0]
       );
@@ -302,7 +314,9 @@ describe("V2DutchOrder", () => {
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(
+        order.info.baseOutputs[0].token
+      );
       expect(resolved.outputs[0].amount).toEqual(
         order.info.cosignerData.outputOverrides[0]
       );
@@ -334,7 +348,9 @@ describe("V2DutchOrder", () => {
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(
+        order.info.baseOutputs[0].token
+      );
       expect(resolved.outputs[0].amount).toEqual(
         order.info.baseOutputs[0].endAmount
       );
@@ -364,7 +380,9 @@ describe("V2DutchOrder", () => {
       );
 
       expect(resolved.outputs.length).toEqual(1);
-      expect(resolved.outputs[0].token).toEqual(order.info.baseOutputs[0].token);
+      expect(resolved.outputs[0].token).toEqual(
+        order.info.baseOutputs[0].token
+      );
       expect(resolved.outputs[0].amount).toEqual(
         order.info.cosignerData.outputOverrides[0]
       );

--- a/src/trade/V2DutchOrderTrade.test.ts
+++ b/src/trade/V2DutchOrderTrade.test.ts
@@ -81,7 +81,7 @@ describe("V2DutchOrderTrade", () => {
   it("works for native output trades", () => {
     const ethOutputOrderInfo = {
       ...orderInfo,
-      outputs: [
+      baseOutputs: [
         {
           token: NativeAssets.ETH,
           startAmount: NON_FEE_OUTPUT_AMOUNT,
@@ -104,7 +104,7 @@ describe("V2DutchOrderTrade", () => {
   it("works for native output trades where order info has 0 address", () => {
     const ethOutputOrderInfo = {
       ...orderInfo,
-      outputs: [
+      baseOutputs: [
         {
           token: constants.AddressZero,
           startAmount: NON_FEE_OUTPUT_AMOUNT,


### PR DESCRIPTION
Needed for order service integration. Creates two separate classes for event watching, one for UniswapX-style orders and one for Relay orders. This is needed because they use different contracts which have different fill event schemas. The export for EventWatcher has been removed and instead you must import either UniswapX/RelayEventWatcher explicity.

Note that the behavior is slightly different between the UniswapX event watcher and the Relay event watcher:

In UniswapX,
- inputs are tokens that are sent to the filler (input tokens from the order)
- outputs are tokens that are sent to the swapper (output tokens from the order)

In relayer,
- inputs are tokens sent to the filler (the feeToken paid by the swapper)
- outputs are tokens sent to the swapper (the output amount from the swap)

This PR also fixes broken unit and integ tests on main